### PR TITLE
Children added to HtmlTagWrapper twice

### DIFF
--- a/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
@@ -883,10 +883,6 @@ namespace Umbraco.Web
 		{
 			var item = html.Wrap(tag, innerText, anonymousAttributes, children);
 			item.Visible = visible;
-			foreach (var child in children)
-			{
-				item.AddChild(child);
-			}
 			return item;
 		}
 


### PR DESCRIPTION
By calling the overload on line 884 the children are added. To do it again results in the children being added twice.